### PR TITLE
NgRestTestCase Added is_api_user to User schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file. This projec
 
 ## 1.0.12 (in progress)
 
++ Fixed issue with NgRestTestCase - Added missing is_api_user to User schema fixture
+
 ## 1.0.11 (18. July 2018)
 
 + [#8](https://github.com/luyadev/luya-testsuite/issues/8) Added new CmsBlockGroupTestCase

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file. This projec
 
 ## 1.0.12 (in progress)
 
-+ Fixed issue with NgRestTestCase - Added missing is_api_user to User schema fixture
++ [#12](https://github.com/luyadev/luya-testsuite/pull/12) Fixed issue with NgRestTestCase - Added missing is_api_user to User schema fixture
 
 ## 1.0.11 (18. July 2018)
 

--- a/src/cases/NgRestTestCase.php
+++ b/src/cases/NgRestTestCase.php
@@ -176,7 +176,8 @@ abstract class NgRestTestCase extends WebApplicationTestCase
                 'firstname' => 'text',
                 'lastname' => 'text',
                 'email' => 'text',
-                'is_deleted' => 'int(11)'
+                'is_deleted' => 'int(11)',
+                'is_api_user' => 'boolean'
             ],
             'fixtureData' => [
                 'user1' => [
@@ -184,7 +185,8 @@ abstract class NgRestTestCase extends WebApplicationTestCase
                     'firstname' => 'John',
                     'lastname' => 'Doe',
                     'email' => 'john@example.com',
-                    'is_deleted' => 0
+                    'is_deleted' => 0,
+                    'is_api_user' => true
                 ]
             ]
         ]);


### PR DESCRIPTION
Added column `is_api_user` to User schema to ensure compatibility with new luya-module-admin.

Error was:
`Getting unknown property: luya\admin\models\User::is_api_user`
Caused by:
`luya-module-admin/src/components/AdminUser.php:73`
